### PR TITLE
Update reminder interval to be an integer for repeat reminder creation

### DIFF
--- a/models/reminder.js
+++ b/models/reminder.js
@@ -1,6 +1,5 @@
 const mongoose = require("mongoose");
 
-const intervalEnum = ["once", "hourly", "daily"];
 const reminderSchema = new mongoose.Schema(
   {
     content: {
@@ -32,11 +31,8 @@ const reminderSchema = new mongoose.Schema(
       required: true,
     },
     interval: {
-      type: String,
-      enum: {
-        values: intervalEnum,
-        message: "Invalid interval: {VALUE}",
-      }
+      type: Number,
+      required: true
     }
   },
   {


### PR DESCRIPTION
## Description

Please provide a brief description of the changes in this pull request.

Update interval field to be an integer so that when the reminder is repeated, we can easily grab the remindDate plus the number of hours to create a new reminder.


## Testing Instructions

If your changes include modifications that need testing, please provide detailed testing instructions. This can include steps to reproduce the issue you're fixing or steps to validate new features or changes.

< Your Response Here >


## Additional Information

Please provide any additional context or information e.g. screenshots, videos about this pull request if necessary.

< Your Response Here >
